### PR TITLE
Fix deprecation warning

### DIFF
--- a/Formula/token-cli.rb
+++ b/Formula/token-cli.rb
@@ -3,7 +3,6 @@ class TokenCli < Formula
   desc "OpenID token generator"
   homepage "https://github.com/imduffy15/token-cli"
   version "1.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/imduffy15/token-cli/releases/download/v1.0.0/token-cli_macOS_amd64.tar.gz"


### PR DESCRIPTION
This PR fixes homebrew deprecation warning

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the imduffy15/tap tap (not Homebrew/brew or Homebrew/core):
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/imduffy15/homebrew-tap/Formula/token-cli.rb:6
```